### PR TITLE
Finish Lox scanner functionality and use a peekable iterator.

### DIFF
--- a/rakitaj/lox_interpreter/src/token.rs
+++ b/rakitaj/lox_interpreter/src/token.rs
@@ -85,7 +85,6 @@ impl fmt::Display for Token {
 
 pub struct SourceCode {
     pub source: String,
-    pub index: usize,
     pub line: usize,
 }
 
@@ -103,13 +102,12 @@ impl SourceCode {
     pub fn new(source: String) -> Self {
         SourceCode {
             source: source,
-            index: 0,
             line: 1,
         }
     }
 
-    pub fn get_string(&self, n: usize) -> String {
-        self.source[self.index..self.index + n].to_string()
+    pub fn get_string(&self, start: usize, length: usize) -> String {
+        self.source[start..start + length].to_string()
     }
 
     pub fn scan_string_literal(&mut self) -> String {
@@ -138,7 +136,8 @@ impl SourceCode {
                 '*' => tokens.push(Token::new(TokenType::Star, self.line)),
                 '/' => {
                     if match_peek(&mut indices, '/') {
-                        indices.take_while(|x| x.1 != '\n');
+                        indices.next();
+                        let _ = indices.by_ref().take_while(|x| x.1 != '\n');
                         self.line +=1 ;
                     } else {
                         tokens.push(Token::new(TokenType::Slash, self.line));
@@ -146,8 +145,8 @@ impl SourceCode {
                 },
                 '!' => {
                     if match_peek(&mut indices, '=') {
-                        tokens.push(Token::new(TokenType::BangEqual, self.line)); 
-                        self.index += 1;
+                        tokens.push(Token::new(TokenType::BangEqual, self.line));
+                        indices.next();
                     } else {
                         tokens.push(Token::new(TokenType::Bang, self.line));
                     }
@@ -155,7 +154,7 @@ impl SourceCode {
                 '=' => {
                     if match_peek(&mut indices, '=') {
                         tokens.push(Token::new(TokenType::EqualEqual, self.line)); 
-                        self.index += 1; 
+                        indices.next();
                     } else {
                         tokens.push(Token::new(TokenType::Equal, self.line));
                     }
@@ -163,7 +162,7 @@ impl SourceCode {
                 '<' => {
                     if match_peek(&mut indices, '=') {
                         tokens.push(Token::new(TokenType::LessEqual, self.line)); 
-                        self.index += 1; 
+                        indices.next();
                     } else {
                         tokens.push(Token::new(TokenType::Less, self.line))
                     }
@@ -171,7 +170,7 @@ impl SourceCode {
                 '>' => {
                     if match_peek(&mut indices, '=') {
                         tokens.push(Token::new(TokenType::GreaterEqual, self.line)); 
-                        self.index += 1; 
+                        indices.next();
                     } else {
                         tokens.push(Token::new(TokenType::Greater, self.line));
                     }
@@ -182,7 +181,6 @@ impl SourceCode {
                 },
                 _ => {},
             }
-            self.index += 1;
         }
         tokens.push(Token::new(TokenType::Eof, self.line));
         return tokens;

--- a/rakitaj/lox_interpreter/src/token.rs
+++ b/rakitaj/lox_interpreter/src/token.rs
@@ -98,6 +98,16 @@ pub fn match_peek(indices: &mut std::iter::Peekable<std::str::CharIndices>, matc
     }
 }
 
+fn take_until(indices: &mut std::iter::Peekable<std::str::CharIndices>, match_char: char) -> usize {
+    let mut count = 0;
+    while let Some(c) = indices.next() {
+        count += 1;
+        if c.1 == match_char {
+            break;
+        }
+    }
+    return count;
+}
 
 pub fn scan_string_literal(indices: &mut std::iter::Peekable<std::str::CharIndices>) -> String {
     "foo".to_string()
@@ -149,8 +159,7 @@ impl SourceCode {
                 '*' => tokens.push(Token::new(TokenType::Star, self.line)),
                 '/' => {
                     if match_peek(&mut indices, '/') {
-                        indices.next();
-                        let _ = indices.by_ref().take_while(|x| x.1 != '\n');
+                        take_until(&mut indices, '\n');
                         self.line +=1 ;
                     } else {
                         tokens.push(Token::new(TokenType::Slash, self.line));
@@ -168,7 +177,6 @@ impl SourceCode {
         return tokens;
     }
 }
-
 
 #[cfg(test)]
 mod tests {
@@ -224,5 +232,14 @@ mod tests {
             Token::new(TokenType::EqualEqual, 1),
             Token::new(TokenType::Bang, 2),
             Token::new(TokenType::Eof, 2)]);
+    }
+
+    #[test]
+    fn test_scan_string_literal() {
+        let mut source = SourceCode::new("\"Hello world!\"".to_string());
+        let tokens = source.scan_tokens();
+        assert_eq!(tokens, vec![
+            Token::new(TokenType::String("Hello world!".to_string()), 1)
+        ]);
     }
 }

--- a/rakitaj/lox_interpreter/src/token.rs
+++ b/rakitaj/lox_interpreter/src/token.rs
@@ -331,4 +331,18 @@ mod tests {
             Token::new(TokenType::Eof, 1)
         ]);
     }
+
+    #[test]
+    fn test_hello_world_line() {
+        let mut source = SourceCode::new("var string = \"Hello world!\";".to_string());
+        let tokens = source.scan_tokens();
+        assert_eq!(tokens, vec![
+            Token::new(TokenType::Var, 1),
+            Token::new(TokenType::Identifier("string".to_string()), 1),
+            Token::new(TokenType::Equal, 1),
+            Token::new(TokenType::String("Hello world!".to_string()), 1),
+            Token::new(TokenType::SemiColon, 1),
+            Token::new(TokenType::Eof, 1)
+        ]);
+    }
 }

--- a/rakitaj/lox_interpreter/src/token.rs
+++ b/rakitaj/lox_interpreter/src/token.rs
@@ -159,7 +159,7 @@ impl SourceCode {
         match_token_type: TokenType,
         not_match_token_type: TokenType,
         tokens: &mut Vec<Token>
-        ) -> () {
+    ) -> () {
             let peek_matches = match_peek(indices, match_char);
             if peek_matches {
                 tokens.push(Token::new(match_token_type, self.line));

--- a/rakitaj/lox_interpreter/src/token.rs
+++ b/rakitaj/lox_interpreter/src/token.rs
@@ -1,5 +1,4 @@
 use std::fmt;
-use std::collections::HashMap;
 
 #[derive(Debug, PartialEq)]
 #[derive(Clone)]
@@ -173,7 +172,7 @@ impl SourceCode {
     pub fn scan_tokens(&mut self) -> Vec<Token> {
         let mut tokens: Vec<Token> = Vec::new();
         let mut indices = self.source.char_indices().peekable();
-        while let Some((i, c)) = indices.next() {
+        while let Some((_i, c)) = indices.next() {
             match c {
                 ' ' => {},
                 '\t' => {},

--- a/rakitaj/lox_interpreter/tests/integration_tests.rs
+++ b/rakitaj/lox_interpreter/tests/integration_tests.rs
@@ -1,0 +1,5 @@
+use crate::test
+
+pub fn prep(filename: &str) -> token::SourceCode {
+    let raw_source = main::load_source(filename);
+}


### PR DESCRIPTION
I finished changing the scanner to use a peekable iterator and added functionality to scan all of the kind of tokens in the Lox language.

The one thing I'm a bit unhappy about is in some of the match arms in the main scanning loop I can't use only `take_while`. I need to keep track of the first character and then concatenate it with the results of `take_while`. That's because the iterator has already consumed the first character when it's in the match arm.

One idea for a future improvement is matching based on `peek` then consuming all of the characters for that token. I already use peek in a few places for the one and two character tokens so it's not like I'm introducing a whole new concept into the scanner.