### PR TITLE
Feat: The Lox interpreter can handle expressions.

### DIFF
--- a/rakitaj/lox_interpreter/src/core/errors.rs
+++ b/rakitaj/lox_interpreter/src/core/errors.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use super::location::Location;
 
 #[derive(Debug, PartialEq, Eq)]
@@ -10,5 +11,15 @@ pub enum LoxError {
 impl LoxError {
     pub fn new_syntax_error(location: Location, message: String) -> Self {
         LoxError::SyntaxError(location, message)
+    }
+}
+
+impl fmt::Display for LoxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoxError::SyntaxError(location, msg) => write!(f, "Syntax Error\n{}\nLocation @ {}", msg, location),
+            LoxError::RuntimeError(location, msg) => write!(f, "Runtime Error\n{}\nLocation @ {}", msg, location),
+            LoxError::Critical(msg) => write!(f, "\nCritical Error\n{}\nNo location can be determinded. Something really bad happened.", msg)
+        }
     }
 }

--- a/rakitaj/lox_interpreter/src/interpreter.rs
+++ b/rakitaj/lox_interpreter/src/interpreter.rs
@@ -4,71 +4,101 @@ use crate::tokens::TokenType;
 use crate::value::Value;
 
 pub struct Interpreter {
-    root_expr: Expr
+    root_expr: Expr,
+    runtime_error: bool
 }
 
 impl Interpreter {
     pub fn new(root_expr: Expr) -> Self {
-        Interpreter { root_expr }
+        Interpreter { 
+            root_expr, 
+            runtime_error: false 
+        }
     }
 
-    pub fn visit_expr(&self, expr: Expr) -> Result<Value, LoxError> {
+    pub fn interpret(mut self) {
+        let result = self.evaluate(&self.root_expr);
+        match result {
+            Ok(x) => println!("{}", x),
+            Err(err) => self.runtime_error(&err)
+        }
+    }
+
+    fn runtime_error(&mut self, err: &LoxError) {
+        self.runtime_error = true;
+        println!("{}", err);
+    }
+
+    fn evaluate(&self, expr: &Expr) -> Result<Value, LoxError> {
         match expr {
             Expr::Literal(_, literal) => {
                 match literal {
                     Literal::Nil => Ok(Value::Nil),
-                    Literal::False => Ok(Value::False),
-                    Literal::True => Ok(Value::True),
-                    Literal::Number(number) => Ok(Value::Number(number)),
-                    Literal::String(string) => Ok(Value::String(string)),
+                    Literal::False => Ok(Value::Boolean(false)),
+                    Literal::True => Ok(Value::Boolean(true)),
+                    Literal::Number(number) => Ok(Value::Number(*number)),
+                    Literal::String(string) => Ok(Value::String(string.to_string())),
                 }
             },
-            Expr::Grouping(grouping) => self.visit_expr(*grouping),
+            Expr::Grouping(grouping) => self.evaluate(grouping),
             Expr::Unary(operator, unary) => {
-                let right: Value = self.visit_expr(*unary)?;
+                let right: Value = self.evaluate(unary)?;
                 match operator.token_type {
                     TokenType::Minus => {
                         match right {
                             Value::Number(number) => Ok(Value::Number(-number)),
                             _ =>  {
                                 let error_msg = format!("Expected Value::Number and got {:?}", right);
-                                Err(LoxError::RuntimeError(operator.location, error_msg))
+                                Err(LoxError::RuntimeError(operator.location.clone(), error_msg))
                             }
                         }
                     },
                     TokenType::Bang => {
                         // Negate, aka flip, the result of is_truthy because this is the bang unary operator.
                         match right.is_truthy() {
-                            true => Ok(Value::False),
-                            false => Ok(Value::True)
+                            true => Ok(Value::Boolean(false)),
+                            false => Ok(Value::Boolean(true))
                         }
                     },
-                    _ => Err(LoxError::RuntimeError(operator.location, "Visiting unary expr and wasn't a unary operator.".to_string()))
+                    _ => Err(LoxError::RuntimeError(operator.location.clone(), "Visiting unary expr and wasn't a unary operator.".to_string()))
                 }
             },
             Expr::Binary(left_expr, operator, right_expr) => {
-                let left = self.visit_expr(*left_expr)?;
-                let right = self.visit_expr(*right_expr)?;
-                match operator.token_type {
-                    TokenType::Minus => {
-                        match (left, right) {
-                            (Value::Number(left_num), Value::Number(right_num)) => Ok(Value::Number(left_num - right_num)),
-                            (left, right) => Err(LoxError::RuntimeError(operator.location, format!("Expected two numbers and got left: {:?} -- right: {:?}", left, right)))
+                let left = self.evaluate(left_expr)?;
+                let right = self.evaluate(right_expr)?;
+                match (left, right) {
+                    (Value::Number(left_num), Value::Number(right_num)) => {
+                        match operator.token_type {
+                            TokenType::Minus => Ok(Value::Number(left_num - right_num)),
+                            TokenType::Slash => Ok(Value::Number(left_num / right_num)),
+                            TokenType::Star => Ok(Value::Number(left_num * right_num)),
+                            TokenType::Plus => Ok(Value::Number(left_num + right_num)),
+                            TokenType::Greater => Ok(Value::Boolean(left_num > right_num)),
+                            TokenType::GreaterEqual => Ok(Value::Boolean(left_num >= right_num)),
+                            TokenType::Less => Ok(Value::Boolean(left_num < right_num)),
+                            TokenType::LessEqual => Ok(Value::Boolean(left_num <= right_num)),
+                            _ => Err(LoxError::RuntimeError(operator.location.clone(), "Should be unreachable".to_string()))
                         }
                     },
-                    TokenType::Slash => {
-                        match (left, right) {
-                            (Value::Number(left_num), Value::Number(right_num)) => Ok(Value::Number(left_num / right_num)),
-                            (left, right) => Err(LoxError::RuntimeError(operator.location, format!("Expected two numbers and got left: {:?} -- right: {:?}", left, right)))
+                    (Value::String(left_string), Value::String(right_string)) => {
+                        match operator.token_type {
+                            TokenType::Plus =>  {
+                                let concat_string = format!("{}{}", left_string, right_string);
+                                Ok(Value::String(concat_string))
+                            },
+                            _ => Err(LoxError::RuntimeError(operator.location.clone(), "Should be unreachable".to_string()))
                         }
-                    },
-                    TokenType::Star => {
-                        match (left, right) {
-                            (Value::Number(left_num), Value::Number(right_num)) => Ok(Value::Number(left_num * right_num)),
-                            (left, right) => Err(LoxError::RuntimeError(operator.location, format!("Expected two numbers and got left: {:?} -- right: {:?}", left, right)))
+                    }
+                    (left, right) => {
+                        match operator.token_type {
+                            TokenType::EqualEqual => Ok(Value::Boolean(left == right)),
+                            TokenType::BangEqual => Ok(Value::Boolean(!(left == right))),
+                            _ => {
+                                let msg = format!("Expected two numbers and got left: {:?} -- right: {:?}", left, right);
+                                Err(LoxError::RuntimeError(operator.location.clone(), msg))
+                            }
                         }
-                    },
-                    _ => Err(LoxError::RuntimeError(operator.location, "Should be unreachable".to_string()))
+                    }
                 }
             },
             _ => Err(LoxError::Critical("Shouldn't get here".to_string()))

--- a/rakitaj/lox_interpreter/src/main.rs
+++ b/rakitaj/lox_interpreter/src/main.rs
@@ -3,6 +3,7 @@ use std::fs;
 use std::io;
 use std::io::prelude::*;
 
+use lox_interpreter::interpreter::Interpreter;
 use lox_interpreter::scanner::SourceCode;
 use lox_interpreter::parser::{Parser, parenthesize};
 
@@ -53,10 +54,12 @@ fn run(raw_source: String) {
     let tokens = source.scan_tokens();
     let mut parser = Parser::new(tokens);
     let ast = parser.parse().unwrap();
-    for token in source.scan_tokens() {
-        println!("{:?}", token);
-    }
-    println!("{}", parenthesize(ast));
+    let interpreter = Interpreter::new(ast);
+    interpreter.interpret();
+    // for token in source.scan_tokens() {
+    //     println!("{:?}", token);
+    // }
+    // println!("{}", parenthesize(ast));
 }
 
 fn load_source(filepath: &str) -> String {

--- a/rakitaj/lox_interpreter/src/main.rs
+++ b/rakitaj/lox_interpreter/src/main.rs
@@ -4,8 +4,14 @@ use std::io;
 use std::io::prelude::*;
 
 use lox_interpreter::interpreter::Interpreter;
+use lox_interpreter::parser::parenthesize;
 use lox_interpreter::scanner::SourceCode;
-use lox_interpreter::parser::{Parser, parenthesize};
+use lox_interpreter::parser::Parser;
+
+enum ReplMode {
+    Standard,
+    Debug
+}
 
 fn main() {
     let args: Vec<String> = env::args().collect();
@@ -14,7 +20,9 @@ fn main() {
     if args.len() == 1 || args[1] == "/?" || args[1] == "--help" || args[1] == "-?" {
         print_help();
     } else if args.len() == 2 && args[1] == "prompt" {
-        run_prompt();
+        run_prompt(ReplMode::Standard);
+    } else if args.len() == 2 && args[1] == "debug-prompt" {
+        run_prompt(ReplMode::Debug);
     } else if args.len() == 3 && args[1] == "rlox" {
         run_file(&args[2]);
     } else {
@@ -26,6 +34,7 @@ fn main() {
 fn print_help() {
     println!("Execute script          : rlox [script]");
     println!("Start interactive prompt: prompt");
+    println!("Start interactive language dev prompt: debug-prompt");
 }
 
 fn run_file(filepath: &str) {
@@ -34,7 +43,7 @@ fn run_file(filepath: &str) {
     
 }
 
-fn run_prompt() {
+fn run_prompt(mode: ReplMode) {
     let stdin = io::stdin();
     for line in stdin.lock().lines() {
         let unwrapped_line = match line {
@@ -44,7 +53,10 @@ fn run_prompt() {
         if unwrapped_line.is_empty() {
             break;
         } else {
-            run(unwrapped_line);
+            match mode {
+                ReplMode::Standard => run(unwrapped_line),
+                ReplMode::Debug => run_debug(unwrapped_line)
+            }
         }
     }
 }
@@ -56,10 +68,24 @@ fn run(raw_source: String) {
     let ast = parser.parse().unwrap();
     let interpreter = Interpreter::new(ast);
     interpreter.interpret();
-    // for token in source.scan_tokens() {
-    //     println!("{:?}", token);
-    // }
-    // println!("{}", parenthesize(ast));
+}
+
+fn run_debug(raw_source: String) {
+    let mut source = SourceCode::new(&raw_source, "repl.lox".to_string());
+    let tokens = source.scan_tokens();
+    
+    for token in &tokens {
+        println!("{:?}", token);
+    }
+    
+    let mut parser = Parser::new(tokens);
+    let ast = parser.parse().unwrap();
+    
+    println!("{}", parenthesize(&ast));
+    
+    let interpreter = Interpreter::new(ast);
+    interpreter.interpret();
+    
 }
 
 fn load_source(filepath: &str) -> String {

--- a/rakitaj/lox_interpreter/src/parser.rs
+++ b/rakitaj/lox_interpreter/src/parser.rs
@@ -222,17 +222,17 @@ pub fn source_to_ast(source: &str, filename: String) -> Result<Expr, LoxError> {
     parser.parse()
 }
 
-pub fn parenthesize(expr: Expr) -> String {
+pub fn parenthesize(expr: &Expr) -> String {
     match expr {
         Expr::Literal(_, Literal::False) => "false".to_string(),
         Expr::Literal(_, Literal::True) => "true".to_string(),
         Expr::Literal(_, Literal::Nil) => "nil".to_string(),
         Expr::Literal(_, Literal::Number(value)) => value.to_string(),
-        Expr::Literal(_, Literal::String(value)) => value,
-        Expr::Grouping(expr) => format!("(group {})", parenthesize(*expr)),
-        Expr::Unary(token, expr) => format!("({} {})", token.token_type, parenthesize(*expr)),
-        Expr::Binary(expr_left, token, expr_right) => format!("({} {} {})", token.token_type, parenthesize(*expr_left), parenthesize(*expr_right)),
-        Expr::Ternary(expr_conditional, expr_left, expr_right) => format!("(ternary {} {} {})", parenthesize(*expr_conditional), parenthesize(*expr_left), parenthesize(*expr_right))
+        Expr::Literal(_, Literal::String(value)) => value.to_string(),
+        Expr::Grouping(expr) => format!("(group {})", parenthesize(expr)),
+        Expr::Unary(token, expr) => format!("({} {})", token.token_type, parenthesize(expr)),
+        Expr::Binary(expr_left, token, expr_right) => format!("({} {} {})", token.token_type, parenthesize(expr_left), parenthesize(expr_right)),
+        Expr::Ternary(expr_conditional, expr_left, expr_right) => format!("(ternary {} {} {})", parenthesize(expr_conditional), parenthesize(expr_left), parenthesize(expr_right))
     }
 }
 
@@ -274,7 +274,7 @@ mod tests {
                 Box::new(Expr::Literal(loc(1), Literal::Number(123.0))))),
             Token::new(TokenType::Star, loc(1)),
             Box::new(Expr::Grouping(Box::new(Expr::Literal(loc(1), Literal::Number(45.67))))));
-        let result = parenthesize(root_expr);
+        let result = parenthesize(&root_expr);
         assert_eq!(result, "(* (- 123) (group 45.67))");
     }
 

--- a/rakitaj/lox_interpreter/src/value.rs
+++ b/rakitaj/lox_interpreter/src/value.rs
@@ -1,8 +1,9 @@
-#[derive(Debug)]
+use std::fmt;
+
+#[derive(Debug, PartialEq)]
 pub enum Value {
     Nil,
-    True,
-    False,
+    Boolean(bool),
     Number(f32),
     String(String),
 }
@@ -10,8 +11,22 @@ pub enum Value {
 impl Value {
     pub fn is_truthy(&self) -> bool {
         match self {
-            Value::False | Value::Nil => false,
+            Value::Boolean(false) | Value::Nil => false,
             _ => true
+        }
+    }
+}
+
+impl fmt::Display for Value {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Value::Nil => write!(f, "nil"),
+            Value::Boolean(x) => match x {
+                true => write!(f, "true"),
+                false => write!(f, "false")
+            },
+            Value::String(x) => write!(f, "{}", x),
+            Value::Number(x) => write!(f, "{}", x)
         }
     }
 }
@@ -24,8 +39,8 @@ mod tests {
 
     #[rstest]
     #[case(Value::Nil, false)]
-    #[case(Value::False, false)]
-    #[case(Value::True, true)]
+    #[case(Value::Boolean(false), false)]
+    #[case(Value::Boolean(true), true)]
     #[case(Value::String("".to_string()), true)]
     fn test_is_truthy(#[case] value: Value, #[case] expected: bool) {
         assert_eq!(value.is_truthy(), expected);

--- a/rakitaj/lox_interpreter/tests/integration_tests.rs
+++ b/rakitaj/lox_interpreter/tests/integration_tests.rs
@@ -1,4 +1,4 @@
-use lox_interpreter::{parser::{Expr, Literal}, tokens::TokenType, core::location::Location};
+use lox_interpreter::{parser::{Expr, Literal}, tokens::{TokenType, Token}, core::location::Location};
 
 fn loc(line: usize) -> Location {
     Location::Line("integration-test.lox".to_string(), line)
@@ -14,12 +14,12 @@ fn test_hardcoded_source_code_to_ast() {
             Box::new(
             Expr::Grouping(Box::new(Expr::Binary(
                 Box::new(Expr::Literal(loc(1), Literal::Number(1.0))), 
-                TokenType::Plus, 
+                Token::new(TokenType::Plus, loc(1)), 
                 Box::new(Expr::Literal(loc(1), Literal::Number(2.0)))
             )))),
-            TokenType::Slash,
+            Token::new(TokenType::Slash, loc(1)),
             Box::new(Expr::Literal(loc(1), Literal::Number(3.0))))),
-        TokenType::EqualEqual,
+        Token::new(TokenType::EqualEqual, loc(1)),
         Box::new(Expr::Literal(loc(1), Literal::Number(1.0))));
     assert_eq!(ast_result.unwrap(), expected_ast)
 }


### PR DESCRIPTION
Finished writing up the rest of the machinery required for supporting expressions and running them via the REPL.

This included:
- Implement `Display` trait for the different enums and structs.
- Finish the binary interpretation operations.
- Changing from a discrete boolean to one that can container either true or false. This makes it much simpler because I can put an expression that evaluates to a boolean directly in the Value.

An unrelated change is the new `debug-prompt` for running a REPL that writes out the tokens scanned and the parsed, parenthesized AST.